### PR TITLE
Update 422 error base class to Error

### DIFF
--- a/templates/src/exceptions.py
+++ b/templates/src/exceptions.py
@@ -32,7 +32,7 @@ class {{config.tap_name}}ConflictError({{config.tap_name}}Error):
     """class representing 409 status code."""
     pass
 
-class {{config.tap_name}}UnprocessableEntityError({{config.tap_name}}BackoffError):
+class {{config.tap_name}}UnprocessableEntityError({{config.tap_name}}Error):
     """class representing 422 status code."""
     pass
 


### PR DESCRIPTION
# Description of change
Updated the UnprocessableEntity class in Exceptions template file to inherit from Error (base error class) instead of Backoff error.
As 422 is not a temporary server problem and we should not backoff in such cases.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
